### PR TITLE
165001992-bug(docs):fix swagger documentation route

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
 import express from 'express';
 import bodyParser from 'body-parser';
+import path from 'path';
 import cors from 'cors';
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yamljs';
+
+import routes from './server/routes';
 
 const app = express();
 const port = process.env.PORT || 5000;
+const swaggerDocument = YAML.load(path.join(process.cwd(), './swagger.yml'));
 
 app.use(cors());
 app.use(require('morgan')('dev'));
@@ -11,6 +17,8 @@ app.use(require('morgan')('dev'));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+app.use('/api/v1', routes);
 
 app.get('/', (req, res) => {
   res.send('Hello Forsetti');


### PR DESCRIPTION
#### Description
- Add a route from which everyone can access the api documentation

#### Type of change
- Bug(none breaking change)

#### How Has This Been Tested?
> Run `npm run start:dev`
> Navigate to `localhost:5000/docs` if on development environment

#### PIVOTAL BOARD
[#165001992](https://www.pivotaltracker.com/n/projects/2320805/stories/165001992)

####SCREENSHOT
None
