### PR TITLE
#165003889 Fix typo in .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-  - "psql -c 'create database forsetti_test;' -U postgres"
+  - psql -c 'create database forsetti_test;' -U postgres
 script:
   - npm ci
   - npm test


### PR DESCRIPTION
#### Description
- Take out double quotes in .travis.yml file **create database** command

#### Type of change
- Bug(none breaking change)

#### How Has This Been Tested?
Can only be testing after PR has been merged and Travis can successfully create the database specified in the .travis.yml file

#### PIVOTAL BOARD
[#165003889](https://www.pivotaltracker.com/story/show/165003889)
