### PR TITLE
#164798929 User should be able to track comment edit history

### DIFF
--- a/server/controllers/comment.controller.js
+++ b/server/controllers/comment.controller.js
@@ -10,7 +10,8 @@ const {
   User,
   DraftComment,
   Article,
-  CommentLike
+  CommentLike,
+  CommentHistory,
 } = db;
 
 /**
@@ -130,6 +131,25 @@ class CommentController {
       userid,
     };
     return Response(res, 201, 'Comment liked successfully', likeObject);
+  }
+
+  /**
+   * Get all comment history
+   * @param {*} req
+   * @param {*} res
+   * @returns {object} response
+   */
+  static async getCommentHistory(req, res) {
+    const { commentId } = req.params;
+    const comment = await Comment.findByPk(commentId);
+    if (!comment) return Response(res, 404, 'Comment does not exist');
+    const commentHistory = await CommentHistory.findAndCountAll({
+      where: { commentId },
+      attributes: {
+        exclude: ['id']
+      },
+    });
+    return Response(res, 200, 'Comment history retrieved successfully', commentHistory);
   }
 }
 

--- a/server/migrations/20190416104305-create-comment-history.js
+++ b/server/migrations/20190416104305-create-comment-history.js
@@ -1,0 +1,41 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('CommentHistories', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4,
+        unique: true,
+        allowNull: false
+      },
+      comment: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      commentId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        onDelete: 'CASCADE',
+        references: {
+          model: 'Comments',
+          key: 'id',
+          as: 'commentId',
+        }
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('now')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('now')
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('CommentHistories');
+  }
+};

--- a/server/models/comment-history.js
+++ b/server/models/comment-history.js
@@ -1,0 +1,24 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const CommentHistory = sequelize.define('CommentHistory', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+      unique: true,
+      allowNull: false
+    },
+    comment: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    commentId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    }
+  }, {});
+  CommentHistory.associate = function (models) {
+    // associations can be defined here
+  };
+  return CommentHistory;
+};

--- a/server/routes/article.routes.js
+++ b/server/routes/article.routes.js
@@ -21,12 +21,13 @@ import {
   verifyText,
   paramsValidate,
   SearchValidators,
-  deleteImage
+  deleteImage,
+  commentIdValidator,
 } from '../utils';
 
 import { signInAuth } from '../utils/users/permissions.util';
 
-const { createComments, threadedComment } = CommentController;
+const { createComments, threadedComment, getCommentHistory } = CommentController;
 const { createOrRemoveBookmark } = BookmarkController;
 const {
   createArticle,
@@ -63,6 +64,8 @@ router.post('/:articleId/bookmark', signInAuth, tryCatch(createOrRemoveBookmark)
 router.put('/:slug', [signInAuth, checkArticleExist, checkAuthor, updateArticle], tryCatch(editArticle));
 
 router.post('/comment/:commentId/like', [signInAuth, doesLikeExistInCommentForUser], tryCatch(CommentController.likeComment));
+
+router.get('/comment/:commentId/history', [commentIdValidator, signInAuth], tryCatch(getCommentHistory));
 
 router.post('/:slug/share', [signInAuth, shareArticleCheck, checkArticleExist], tryCatch(shareArticle));
 

--- a/server/seeders/20190416094115-comments.js
+++ b/server/seeders/20190416094115-comments.js
@@ -1,0 +1,23 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.bulkInsert('Comments', [
+    {
+      id: 'c22c38cf-894c-417c-acf8-68eb0712bdaa',
+      userId: 'b2b67e1e-d40c-47ef-8abf-62e1a330d4ef',
+      articleId: 'efbd2ccd-4e06-4ecb-bfe0-baf303cd5577',
+      comment: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla interdum'
+    },
+    {
+      id: 'c0f22eac-218b-43ff-b998-caf67d5b9ce8',
+      userId: 'fcc7773a-cff8-4ee2-9f8e-1d506b4e27c8',
+      articleId: 'efbd2ccd-4e06-4ecb-bfe0-baf303cd5577',
+      comment: 'Fusce aliquet metus at tristique dapibus'
+    },
+    {
+      id: 'bcf38432-2c98-4008-afaf-e510eb9c69e5',
+      userId: 'fcc7773a-cff8-4ee2-9f8e-1d506b4e27c8',
+      articleId: 'efbd2ccd-4e06-4ecb-bfe0-baf303cd5577',
+      comment: 'Quisque ultrices nunc at quam vulputate, vitae maximus risus pharetra'
+    }
+  ], {}),
+  down: (queryInterface, Sequelize) => queryInterface.bulkDelete('Comments', null, {})
+};

--- a/server/seeders/20190416140323-comment-history.js
+++ b/server/seeders/20190416140323-comment-history.js
@@ -1,0 +1,15 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.bulkInsert('CommentHistories', [
+    {
+      id: '551f7399-e112-423b-abff-8e5e6b6f95cb',
+      comment: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla interdum | updated first',
+      commentId: 'c22c38cf-894c-417c-acf8-68eb0712bdaa'
+    },
+    {
+      id: 'e3852a8e-8fa9-4f27-bf6f-3afc09643c16',
+      comment: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla interdum | updated again',
+      commentId: 'c22c38cf-894c-417c-acf8-68eb0712bdaa'
+    }
+  ], {}),
+  down: (queryInterface, Sequelize) => queryInterface.bulkDelete('CommentHistories', null, {})
+};

--- a/server/utils/commentidvalidator.util.js
+++ b/server/utils/commentidvalidator.util.js
@@ -1,0 +1,18 @@
+import isUUID from 'validator/lib/isUUID';
+import Response from './response.util';
+
+/**
+ * @description Checks if the commentid is valid
+ * @param {Object} req
+ * @param {Object} res
+ * @param {function} next
+ * @returns {Object} response
+ */
+const commentIdValidator = (req, res, next) => {
+  const { commentId } = req.params;
+
+  if (!isUUID(commentId, 4)) return Response(res, 400, 'Please enter a valid id.');
+  return next();
+};
+
+export default commentIdValidator;

--- a/server/utils/comments/comment-history.util.js
+++ b/server/utils/comments/comment-history.util.js
@@ -1,0 +1,32 @@
+import db from '../../models';
+
+const { Comment, CommentHistory } = db;
+
+/**
+ * Insert current comment into CommentHistories table
+ * @param {int} commentId
+ * @returns {Boolean} true/false
+ */
+const saveCommentHistory = async (commentId) => {
+  let success;
+  try {
+    const currentComment = await Comment.findByPk(commentId);
+    if (currentComment !== null) {
+      const { comment } = currentComment;
+      const commentHistory = await CommentHistory.create({
+        comment,
+        commentId,
+      });
+      success = true;
+      return success;
+    }
+    // if we get here, comment doesn't exist
+    success = false;
+    return success;
+  } catch (error) {
+    success = false;
+    return success;
+  }
+};
+
+export default saveCommentHistory;

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -20,6 +20,8 @@ import likeValidation from './comments/check-comment-like.util';
 import verifyHighlightedText from './articles/highlightvalidate.util';
 import SearchValidators from './articles/article-search.utils';
 import deleteImage from './articles/deleteImage.util';
+import saveCommentHistory from './comments/comment-history.util';
+import commentIdValidator from './commentidvalidator.util';
 
 const {
   userSignup, userExist, isSigninFieldEmpty, validateRole, validateProfile,
@@ -78,5 +80,7 @@ export {
   paramsValidate,
   SearchValidators,
   deleteImage,
-  checkUsername
+  checkUsername,
+  saveCommentHistory,
+  commentIdValidator,
 };

--- a/swagger.yml
+++ b/swagger.yml
@@ -702,6 +702,41 @@ paths:
                   email: "o.yes@gmail.com"
         503:
           description: "Some error occurred"
+  
+  /article/comment/:commentid/history:
+    get:
+      summary: Handles getting comment edit history
+      description: Get all comments history by a commentId
+      tags:
+        - Comments
+      produces:
+        - application/json
+      security:
+        - Bearer: []
+      parameters:
+        - in: path
+          name: commentid
+          required: true
+          type: uuid
+          description: Id of the comment.
+      responses:
+        200:
+          description: Comment history was received successfully
+          example:
+            status: 200
+            message: Comment history retrieved successfully
+            data:
+              count: 2
+              rows:
+                - comment: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla interdum | updated first"
+                  commentId: "c22c38cf-894c-417c-acf8-68eb0712bdaa"
+                  createdAt: "2019-04-16T15:02:34.602Z"
+                  updatedAt: "2019-04-16T15:02:34.602Z"
+        404:
+          description: Comment with the given id was not found in the database
+          example:
+            status: 404
+            error: Comment does not exist.
   /reports:
     post:
       tags:


### PR DESCRIPTION
#### Description
Implements the feature that enables the user to view the edit history on comments.
#### Type of change
- [x]  Non-breaking change(introduces new endpoint to codebase)
#### How Has This Been Tested?
- All tests are currently passing
- It was also tested on Postman

##### Screenshots
<img width="972" alt="Screenshot 2019-04-16 at 4 10 39 PM" src="https://user-images.githubusercontent.com/31559138/56222903-b61f2000-6064-11e9-852b-b2dfd2148179.png">


#### Checklist:
- [x]  Create seeder for Comments model
- [x]  Create CommentHistory model
- [x] Create migration for CommentHistory model
- [x] Write tests for save comment history function
- [x] Write code to make save comment history function pass
- [x] Write code to make retrieve comments history endpoint work
- [x] Write tests for retrieve comment history endpoint

#### PIVOTAL BOARD
[#164798929](https://www.pivotaltracker.com/story/show/164798929)